### PR TITLE
[FIX] Splash Screen + Page History Update

### DIFF
--- a/StudyBox/src/components/api/auth.ts
+++ b/StudyBox/src/components/api/auth.ts
@@ -1,7 +1,9 @@
 import axios, {AxiosError} from 'axios';
 import {Alert} from 'react-native';
-import {API} from '../../../config';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {API} from '../../../config';
+import {resetPageHistory} from '../elements/controllers/navigation';
 
 const storeData = async (key: string, value: string) => {
   try {
@@ -22,7 +24,7 @@ export async function login(
     });
     console.log(auth.data);
     storeData('token', auth.data.token);
-    navigation.navigate('HomePageScreen');
+    resetPageHistory(navigation, 'HomePageScreen');
     return auth;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/StudyBox/src/components/elements/controllers/navigation.tsx
+++ b/StudyBox/src/components/elements/controllers/navigation.tsx
@@ -1,0 +1,6 @@
+export function resetPageHistory(navigation: any, defaultPage: string) {
+  navigation.reset({
+    index: 0,
+    routes: [{name: defaultPage}],
+  });
+}

--- a/StudyBox/src/components/pages/splashScreen.tsx
+++ b/StudyBox/src/components/pages/splashScreen.tsx
@@ -2,6 +2,8 @@ import React, {Component} from 'react';
 import {View, Image, StyleSheet} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+import {resetPageHistory} from '../elements/controllers/navigation';
+
 const getData = async (key: string): Promise<boolean> => {
   try {
     const value = await AsyncStorage.getItem(key);
@@ -18,21 +20,14 @@ const getData = async (key: string): Promise<boolean> => {
 };
 
 export class SplashScreen extends Component<Props> {
-  resetPageHistory(defaultPage: string) {
-    this.props.navigation.reset({
-      index: 0,
-      routes: [{name: defaultPage}],
-    });
-  }
-
   componentDidMount() {
     setTimeout(
       () =>
         getData('token').then(res => {
           if (res === true) {
-            this.resetPageHistory('HomePageScreen');
+            resetPageHistory(this.props.navigation, 'HomePageScreen');
           } else {
-            this.resetPageHistory('AuthScreen');
+            resetPageHistory(this.props.navigation, 'AuthScreen');
           }
         }),
       800,


### PR DESCRIPTION
Splash Screen can not longer be displayed by pressing the *Back Button*.
Auth Screens are not longer available after Authentication
Splash Screen is now displayed in the entire Mobile Screen (responsive)